### PR TITLE
Display more fields on boardgame detail screen (#2)

### DIFF
--- a/BoardGameGeek.xcodeproj/project.pbxproj
+++ b/BoardGameGeek.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		7803031C2985FBDC00A0BA35 /* ShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7803031B2985FBDC00A0BA35 /* ShadowView.swift */; };
 		7803031E2986161900A0BA35 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7803031D2986161900A0BA35 /* Colors.swift */; };
 		7803032129876D9000A0BA35 /* Alert+showError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7803032029876D9000A0BA35 /* Alert+showError.swift */; };
+		78030324298775D700A0BA35 /* ViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78030323298775D700A0BA35 /* ViewModelProtocol.swift */; };
 		78E3EC44297FA56600A56B65 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E3EC43297FA56600A56B65 /* AppDelegate.swift */; };
 		78E3EC46297FA56600A56B65 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E3EC45297FA56600A56B65 /* SceneDelegate.swift */; };
 		78E3EC48297FA56600A56B65 /* BoardGameController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E3EC47297FA56600A56B65 /* BoardGameController.swift */; };
@@ -43,6 +44,7 @@
 		7803031B2985FBDC00A0BA35 /* ShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowView.swift; sourceTree = "<group>"; };
 		7803031D2986161900A0BA35 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		7803032029876D9000A0BA35 /* Alert+showError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Alert+showError.swift"; sourceTree = "<group>"; };
+		78030323298775D700A0BA35 /* ViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelProtocol.swift; sourceTree = "<group>"; };
 		78E3EC40297FA56600A56B65 /* BoardGameGeek.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoardGameGeek.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		78E3EC43297FA56600A56B65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		78E3EC45297FA56600A56B65 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 			children = (
 				78E3EC6A29833D1900A56B65 /* Detail */,
 				78E3EC6929833D0E00A56B65 /* SearchList */,
+				78030323298775D700A0BA35 /* ViewModelProtocol.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -302,6 +305,7 @@
 				780303192985303900A0BA35 /* EmptyTableCellViewModel.swift in Sources */,
 				78E3EC6E29833D7900A56B65 /* DetailViewController.swift in Sources */,
 				78E3EC60297FA9BD00A56B65 /* BoardGame.swift in Sources */,
+				78030324298775D700A0BA35 /* ViewModelProtocol.swift in Sources */,
 				78E3EC7029833D8E00A56B65 /* DetailViewModel.swift in Sources */,
 				7803031729852C3C00A0BA35 /* BoardGameCellViewModel.swift in Sources */,
 				78E3EC5C297FA71D00A56B65 /* BoardGameService.swift in Sources */,

--- a/BoardGameGeek.xcodeproj/project.pbxproj
+++ b/BoardGameGeek.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		780303192985303900A0BA35 /* EmptyTableCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780303182985303900A0BA35 /* EmptyTableCellViewModel.swift */; };
 		7803031C2985FBDC00A0BA35 /* ShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7803031B2985FBDC00A0BA35 /* ShadowView.swift */; };
 		7803031E2986161900A0BA35 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7803031D2986161900A0BA35 /* Colors.swift */; };
+		7803032129876D9000A0BA35 /* Alert+showError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7803032029876D9000A0BA35 /* Alert+showError.swift */; };
 		78E3EC44297FA56600A56B65 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E3EC43297FA56600A56B65 /* AppDelegate.swift */; };
 		78E3EC46297FA56600A56B65 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E3EC45297FA56600A56B65 /* SceneDelegate.swift */; };
 		78E3EC48297FA56600A56B65 /* BoardGameController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E3EC47297FA56600A56B65 /* BoardGameController.swift */; };
@@ -41,6 +42,7 @@
 		780303182985303900A0BA35 /* EmptyTableCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTableCellViewModel.swift; sourceTree = "<group>"; };
 		7803031B2985FBDC00A0BA35 /* ShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowView.swift; sourceTree = "<group>"; };
 		7803031D2986161900A0BA35 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
+		7803032029876D9000A0BA35 /* Alert+showError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Alert+showError.swift"; sourceTree = "<group>"; };
 		78E3EC40297FA56600A56B65 /* BoardGameGeek.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoardGameGeek.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		78E3EC43297FA56600A56B65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		78E3EC45297FA56600A56B65 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 			children = (
 				780303132985149700A0BA35 /* String+withXMLChars.swift */,
 				7803031D2986161900A0BA35 /* Colors.swift */,
+				7803032029876D9000A0BA35 /* Alert+showError.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -290,6 +293,7 @@
 				780303122984FC2000A0BA35 /* EmptyTableViewCell.swift in Sources */,
 				78E3EC74298363A200A56B65 /* DetailParser.swift in Sources */,
 				78E3EC46297FA56600A56B65 /* SceneDelegate.swift in Sources */,
+				7803032129876D9000A0BA35 /* Alert+showError.swift in Sources */,
 				7803031E2986161900A0BA35 /* Colors.swift in Sources */,
 				78E3EC762983836C00A56B65 /* StoryboardProtocol.swift in Sources */,
 				78E3EC7229833DD500A56B65 /* BoardGameDetails.swift in Sources */,

--- a/BoardGameGeek/Base.lproj/Main.storyboard
+++ b/BoardGameGeek/Base.lproj/Main.storyboard
@@ -125,21 +125,21 @@
                                 <rect key="frame" x="0.0" y="75" width="393" height="743"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="BTc-Fu-bqj">
-                                        <rect key="frame" x="0.0" y="20" width="394" height="394.33333333333331"/>
+                                        <rect key="frame" x="0.0" y="20" width="394" height="448.33333333333331"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Smg-wB-Jeq" customClass="ShadowView" customModule="BoardGameGeek" customModuleProvider="target">
-                                                <rect key="frame" x="77" y="0.0" width="240" height="240"/>
+                                                <rect key="frame" x="47" y="0.0" width="300" height="300"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nTE-Vj-JZB" customClass="RoundedImageView" customModule="BoardGameGeek" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="0.0" width="240" height="240"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="300" height="300"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="nTE-Vj-JZB" secondAttribute="height" multiplier="1:1" id="8Vh-cU-1c1"/>
                                                             <constraint firstAttribute="width" constant="200" id="Kmh-fU-RYT"/>
-                                                            <constraint firstAttribute="height" constant="240" id="v6G-bw-gTT"/>
+                                                            <constraint firstAttribute="height" constant="300" id="v6G-bw-gTT"/>
                                                         </constraints>
                                                         <userDefinedRuntimeAttributes>
                                                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                                <real key="value" value="120"/>
+                                                                <real key="value" value="150"/>
                                                             </userDefinedRuntimeAttribute>
                                                         </userDefinedRuntimeAttributes>
                                                         <variation key="default">
@@ -151,7 +151,7 @@
                                                 </subviews>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="240" id="Znz-ve-UB6"/>
+                                                    <constraint firstAttribute="width" constant="300" id="Znz-ve-UB6"/>
                                                     <constraint firstAttribute="width" secondItem="Smg-wB-Jeq" secondAttribute="height" multiplier="1:1" id="eY5-pL-Pt9"/>
                                                     <constraint firstItem="nTE-Vj-JZB" firstAttribute="centerX" secondItem="Smg-wB-Jeq" secondAttribute="centerX" id="niW-fx-kb7"/>
                                                     <constraint firstItem="nTE-Vj-JZB" firstAttribute="centerY" secondItem="Smg-wB-Jeq" secondAttribute="centerY" id="po7-bP-0wl"/>
@@ -164,7 +164,7 @@
                                                         <real key="value" value="10"/>
                                                     </userDefinedRuntimeAttribute>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                        <real key="value" value="120"/>
+                                                        <real key="value" value="150"/>
                                                     </userDefinedRuntimeAttribute>
                                                     <userDefinedRuntimeAttribute type="size" keyPath="shadowOffset">
                                                         <size key="value" width="0.0" height="0.0"/>
@@ -172,7 +172,7 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="rSS-P2-Acn">
-                                                <rect key="frame" x="177" y="258" width="40" height="24"/>
+                                                <rect key="frame" x="177" y="318" width="40" height="24"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fgh-H8-TRh">
                                                         <rect key="frame" x="20" y="8" width="0.0" height="0.0"/>
@@ -191,7 +191,7 @@
                                                 <edgeInsets key="layoutMargins" top="8" left="20" bottom="8" right="20"/>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" id="zN0-37-1lW">
-                                                <rect key="frame" x="197" y="300" width="0.0" height="0.0"/>
+                                                <rect key="frame" x="197" y="360" width="0.0" height="0.0"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="QhZ-mz-0qh">
@@ -210,7 +210,7 @@
                                                 <viewLayoutGuide key="safeArea" id="Cf6-u1-DeE"/>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="baE-hn-2OG">
-                                                <rect key="frame" x="197" y="318" width="0.0" height="0.0"/>
+                                                <rect key="frame" x="197" y="378" width="0.0" height="0.0"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="4x0-yP-uxc">
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -226,8 +226,8 @@
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="gTC-0y-SIi">
-                                                <rect key="frame" x="122.00000000000001" y="336" width="150.33333333333337" height="58.333333333333314"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="gTC-0y-SIi">
+                                                <rect key="frame" x="122.00000000000001" y="396" width="150.33333333333337" height="52.333333333333314"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="iRA-NP-YZd">
                                                         <rect key="frame" x="19.999999999999993" y="8" width="110.33333333333331" height="0.0"/>
@@ -237,7 +237,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qOg-Lg-qaG">
-                                                        <rect key="frame" x="19.999999999999993" y="16.000000000000004" width="110.33333333333331" height="34.333333333333343"/>
+                                                        <rect key="frame" x="19.999999999999993" y="10" width="110.33333333333331" height="34.333333333333336"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Learn More"/>
                                                         <connections>

--- a/BoardGameGeek/Base.lproj/Main.storyboard
+++ b/BoardGameGeek/Base.lproj/Main.storyboard
@@ -125,7 +125,7 @@
                                 <rect key="frame" x="0.0" y="75" width="393" height="743"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="BTc-Fu-bqj">
-                                        <rect key="frame" x="0.0" y="20" width="394" height="352"/>
+                                        <rect key="frame" x="0.0" y="20" width="394" height="394.33333333333331"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Smg-wB-Jeq" customClass="ShadowView" customModule="BoardGameGeek" customModuleProvider="target">
                                                 <rect key="frame" x="77" y="0.0" width="240" height="240"/>
@@ -226,16 +226,24 @@
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="gTC-0y-SIi">
-                                                <rect key="frame" x="177" y="336" width="40" height="16"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="gTC-0y-SIi">
+                                                <rect key="frame" x="122.00000000000001" y="336" width="150.33333333333337" height="58.333333333333314"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="iRA-NP-YZd">
-                                                        <rect key="frame" x="20" y="8" width="0.0" height="0.0"/>
+                                                        <rect key="frame" x="19.999999999999993" y="8" width="110.33333333333331" height="0.0"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qOg-Lg-qaG">
+                                                        <rect key="frame" x="19.999999999999993" y="16.000000000000004" width="110.33333333333331" height="34.333333333333343"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="Learn More"/>
+                                                        <connections>
+                                                            <action selector="learnMoreTapped:" destination="6tX-NP-72k" eventType="touchUpInside" id="aso-gE-NZB"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
                                                 <edgeInsets key="layoutMargins" top="8" left="20" bottom="8" right="20"/>
                                             </stackView>
@@ -273,6 +281,7 @@
                         <outlet property="descriptionLabel" destination="iRA-NP-YZd" id="BgJ-Lu-JM9"/>
                         <outlet property="imageContainerView" destination="Smg-wB-Jeq" id="ldg-zc-jQd"/>
                         <outlet property="imageView" destination="nTE-Vj-JZB" id="3nk-39-pq0"/>
+                        <outlet property="learnMoreButton" destination="qOg-Lg-qaG" id="WFv-kx-0jx"/>
                         <outlet property="maximumPlayerLabel" destination="m3I-Bj-cTz" id="luZ-4I-w7v"/>
                         <outlet property="minimumPlayerLabel" destination="QhZ-mz-0qh" id="guZ-eW-jN9"/>
                         <outlet property="nameLabel" destination="Fgh-H8-TRh" id="U8x-Fn-ibt"/>

--- a/BoardGameGeek/Base.lproj/Main.storyboard
+++ b/BoardGameGeek/Base.lproj/Main.storyboard
@@ -125,7 +125,7 @@
                                 <rect key="frame" x="0.0" y="75" width="393" height="743"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="BTc-Fu-bqj">
-                                        <rect key="frame" x="0.0" y="20" width="394" height="448.33333333333331"/>
+                                        <rect key="frame" x="0.0" y="20" width="394" height="532.33333333333337"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Smg-wB-Jeq" customClass="ShadowView" customModule="BoardGameGeek" customModuleProvider="target">
                                                 <rect key="frame" x="47" y="0.0" width="300" height="300"/>
@@ -191,7 +191,7 @@
                                                 <edgeInsets key="layoutMargins" top="8" left="20" bottom="8" right="20"/>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" id="zN0-37-1lW">
-                                                <rect key="frame" x="197" y="360" width="0.0" height="0.0"/>
+                                                <rect key="frame" x="197" y="410" width="0.0" height="0.0"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="QhZ-mz-0qh">
@@ -229,7 +229,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="gTC-0y-SIi">
                                                 <rect key="frame" x="122.00000000000001" y="396" width="150.33333333333337" height="52.333333333333314"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="iRA-NP-YZd">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="iRA-NP-YZd">
                                                         <rect key="frame" x="19.999999999999993" y="8" width="110.33333333333331" height="0.0"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -244,6 +244,36 @@
                                                             <action selector="learnMoreTapped:" destination="6tX-NP-72k" eventType="touchUpInside" id="aso-gE-NZB"/>
                                                         </connections>
                                                     </button>
+                                                </subviews>
+                                                <edgeInsets key="layoutMargins" top="8" left="20" bottom="8" right="20"/>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="XRB-jb-K3a">
+                                                <rect key="frame" x="152" y="466.33333333333337" width="90" height="66"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lfd-5a-Kqz">
+                                                        <rect key="frame" x="20" y="8" width="50" height="50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LA7-Yy-E9q">
+                                                        <rect key="frame" x="20" y="58" width="50" height="0.0"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K0v-GI-piR">
+                                                        <rect key="frame" x="20" y="58" width="50" height="0.0"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nar-2u-qI7">
+                                                        <rect key="frame" x="20" y="58" width="50" height="0.0"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
                                                 </subviews>
                                                 <edgeInsets key="layoutMargins" top="8" left="20" bottom="8" right="20"/>
                                             </stackView>
@@ -277,14 +307,18 @@
                     </view>
                     <connections>
                         <outlet property="activityIndicatorView" destination="wg4-oL-IvT" id="x0e-dZ-FXu"/>
+                        <outlet property="ageLabel" destination="Lfd-5a-Kqz" id="1lT-ku-dpo"/>
                         <outlet property="categoryLabel" destination="4x0-yP-uxc" id="Au2-on-aaC"/>
                         <outlet property="descriptionLabel" destination="iRA-NP-YZd" id="BgJ-Lu-JM9"/>
                         <outlet property="imageContainerView" destination="Smg-wB-Jeq" id="ldg-zc-jQd"/>
                         <outlet property="imageView" destination="nTE-Vj-JZB" id="3nk-39-pq0"/>
                         <outlet property="learnMoreButton" destination="qOg-Lg-qaG" id="WFv-kx-0jx"/>
                         <outlet property="maximumPlayerLabel" destination="m3I-Bj-cTz" id="luZ-4I-w7v"/>
+                        <outlet property="maximumPlayingTimeLabel" destination="Nar-2u-qI7" id="J83-Ov-Oc3"/>
                         <outlet property="minimumPlayerLabel" destination="QhZ-mz-0qh" id="guZ-eW-jN9"/>
+                        <outlet property="minimumPlayingTimeLabel" destination="K0v-GI-piR" id="Qj6-E5-Ndr"/>
                         <outlet property="nameLabel" destination="Fgh-H8-TRh" id="U8x-Fn-ibt"/>
+                        <outlet property="playingTimeLabel" destination="LA7-Yy-E9q" id="xSg-U0-6Oh"/>
                         <outlet property="publisherLabel" destination="JL1-uu-NqE" id="mrN-pr-AzR"/>
                         <outlet property="yearLabel" destination="w76-aN-86I" id="ajh-UQ-iEj"/>
                     </connections>

--- a/BoardGameGeek/Extensions/Alert+showError.swift
+++ b/BoardGameGeek/Extensions/Alert+showError.swift
@@ -1,0 +1,21 @@
+//
+//  Alert+showError.swift
+//  BoardGameGeek
+//
+//  Created by Nafisa Rahman on 30/1/2023.
+//
+
+import UIKit
+
+extension UIViewController {
+
+    func showError(_ error: Error) {
+        let alertController = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
+        let alertAction = UIAlertAction(title: "OK", style: .default) { [unowned self] _ in
+            self.dismiss(animated: true, completion: nil)
+        }
+        alertController.addAction(alertAction)
+        present(alertController, animated: true, completion: nil)
+    }
+
+}

--- a/BoardGameGeek/Service/BoardGameService.swift
+++ b/BoardGameGeek/Service/BoardGameService.swift
@@ -53,6 +53,7 @@ private extension BoardGameService {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw NetworkError.unknown
         }
+        
         switch httpResponse.statusCode {
         case 200...299:
             break

--- a/BoardGameGeek/Service/DetailParser.swift
+++ b/BoardGameGeek/Service/DetailParser.swift
@@ -11,8 +11,8 @@ final class DetailParser: NSObject {
 
     // MARK: - properties
 
-    var boardGameDetails: BoardGameDetails
-    var currentValue: String
+    private var boardGameDetails: BoardGameDetails
+    private var currentValue: String
 
     override init() {
         currentValue = ""

--- a/BoardGameGeek/Service/SearchResultParser.swift
+++ b/BoardGameGeek/Service/SearchResultParser.swift
@@ -11,8 +11,8 @@ final class SearchResultParser: NSObject {
 
     // MARK: - properties
 
-    var boardGames: [BoardGame]
-    var currentValue: String
+    private var boardGames: [BoardGame]
+    private var currentValue: String
 
     override init() {
         boardGames = []

--- a/BoardGameGeek/View/Detail/DetailViewController.swift
+++ b/BoardGameGeek/View/Detail/DetailViewController.swift
@@ -23,10 +23,12 @@ final class DetailViewController: UIViewController {
     @IBOutlet private weak var publisherLabel: UILabel!
 
     @IBOutlet private weak var descriptionLabel: UILabel!
+    @IBOutlet private weak var learnMoreButton: UIButton!
 
     @IBOutlet private weak var activityIndicatorView: UIActivityIndicatorView!
 
     private var detailViewModel: DetailViewModel!
+    private var isLearnMoreButtonTapped: Bool = false
 
     public var objectID: String?
 
@@ -48,7 +50,24 @@ final class DetailViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         self.view.frame = CGRect(origin: .zero, size: view.bounds.size)
         self.view.setNeedsDisplay()
+        self.view.layoutIfNeeded()
+        self.view.layoutSubviews()
     }
+
+    @IBAction func learnMoreTapped(_ sender: UIButton) {
+        isLearnMoreButtonTapped.toggle()
+
+        if isLearnMoreButtonTapped {
+            descriptionLabel.numberOfLines = 0
+            descriptionLabel.lineBreakMode = .byWordWrapping
+            learnMoreButton.setTitle("Learn Less", for: .normal)
+        } else {
+            descriptionLabel.numberOfLines = 2
+            descriptionLabel.lineBreakMode = .byTruncatingTail
+            learnMoreButton.setTitle("Learn More", for: .normal)
+        }
+    }
+
 }
 
 private extension DetailViewController {
@@ -87,6 +106,8 @@ private extension DetailViewController {
         nameLabel.text = detailViewModel.name
         yearLabel.text = detailViewModel.year
         descriptionLabel.text = detailViewModel.description
+        descriptionLabel.numberOfLines = 2
+        descriptionLabel.lineBreakMode = .byTruncatingTail
 
         maximumPlayerLabel.text = detailViewModel.maxPlayer
         maximumPlayerLabel.isHidden = detailViewModel.isMaxPlayerHidden

--- a/BoardGameGeek/View/Detail/DetailViewController.swift
+++ b/BoardGameGeek/View/Detail/DetailViewController.swift
@@ -50,6 +50,7 @@ final class DetailViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         imageView.isHidden = true
         imageContainerView.isHidden = true
+        learnMoreButton.isHidden = true
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -106,7 +107,9 @@ private extension DetailViewController {
                 self?.activityIndicatorView.stopAnimating()
                 navigationItem.hidesBackButton = false
             } catch {
-                print(error) // handle later
+                self?.activityIndicatorView.stopAnimating()
+                navigationItem.hidesBackButton = false
+                self?.showError(error)
             }
         }
     }
@@ -117,6 +120,7 @@ private extension DetailViewController {
         descriptionLabel.text = detailViewModel.description
         descriptionLabel.numberOfLines = 2
         descriptionLabel.lineBreakMode = .byTruncatingTail
+        learnMoreButton.isHidden = false
 
         maximumPlayerLabel.text = detailViewModel.maxPlayer
         maximumPlayerLabel.isHidden = detailViewModel.isMaxPlayerHidden
@@ -150,7 +154,7 @@ private extension DetailViewController {
                     imageContainerView.isHidden = detailViewModel.isImageHidden
                 }
             } catch {
-                // throw error
+                self?.showError(error)
             }
         }
     }

--- a/BoardGameGeek/View/Detail/DetailViewController.swift
+++ b/BoardGameGeek/View/Detail/DetailViewController.swift
@@ -25,6 +25,11 @@ final class DetailViewController: UIViewController {
     @IBOutlet private weak var descriptionLabel: UILabel!
     @IBOutlet private weak var learnMoreButton: UIButton!
 
+    @IBOutlet private weak var ageLabel: UILabel!
+    @IBOutlet private weak var playingTimeLabel: UILabel!
+    @IBOutlet private weak var minimumPlayingTimeLabel: UILabel!
+    @IBOutlet private weak var maximumPlayingTimeLabel: UILabel!
+
     @IBOutlet private weak var activityIndicatorView: UIActivityIndicatorView!
 
     private var detailViewModel: DetailViewModel!
@@ -78,6 +83,10 @@ private extension DetailViewController {
         maximumPlayerLabel.textColor = .secondaryTitleColor
         categoryLabel.textColor = .secondaryTitleColor
         publisherLabel.textColor = .secondaryTitleColor
+        ageLabel.textColor = .secondaryTitleColor
+        playingTimeLabel.textColor = .secondaryTitleColor
+        minimumPlayingTimeLabel.textColor = .secondaryTitleColor
+        maximumPlayingTimeLabel.textColor = .secondaryTitleColor
     }
 
     func configureViewModel() {
@@ -118,6 +127,15 @@ private extension DetailViewController {
         categoryLabel.isHidden = detailViewModel.isCategoryHidden
         publisherLabel.text = detailViewModel.publisher
         publisherLabel.isHidden = detailViewModel.ispublisherHidden
+
+        ageLabel.text = detailViewModel.age
+        ageLabel.isHidden = detailViewModel.isAgeHidden
+        playingTimeLabel.text = detailViewModel.playingTime
+        playingTimeLabel.isHidden = detailViewModel.isPlayingTimeHidden
+        minimumPlayingTimeLabel.text = detailViewModel.minimumPlayingTime
+        minimumPlayingTimeLabel.isHidden = detailViewModel.isMinimumPlayingTimeHidden
+        maximumPlayingTimeLabel.text = detailViewModel.maximumPlayingTime
+        maximumPlayingTimeLabel.isHidden = detailViewModel.ismMaximumPlayingTimeHidden
 
         showImage()
     }

--- a/BoardGameGeek/View/Detail/DetailViewController.swift
+++ b/BoardGameGeek/View/Detail/DetailViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class DetailViewController: UIViewController {
+final class DetailViewController: UIViewController, ViewModelProtocol {
 
     // MARK: - properties
 
@@ -32,17 +32,14 @@ final class DetailViewController: UIViewController {
 
     @IBOutlet private weak var activityIndicatorView: UIActivityIndicatorView!
 
-    private var detailViewModel: DetailViewModel!
+    var viewModel: DetailViewModel!
     private var isLearnMoreButtonTapped: Bool = false
-
-    public var objectID: String?
 
     // MARK: - ViewController lifecycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        configureViewModel()
         fetchGameDetails()
         configureStyle()
     }
@@ -90,18 +87,13 @@ private extension DetailViewController {
         maximumPlayingTimeLabel.textColor = .secondaryTitleColor
     }
 
-    func configureViewModel() {
-        detailViewModel = DetailViewModel(boardGameService: BoardGameService(parser: DetailParser()))
-    }
-
     func fetchGameDetails() {
         Task { [weak self] in
             do {
                 self?.activityIndicatorView.startAnimating()
                 navigationItem.hidesBackButton = true
 
-                guard let objectID = objectID else { return }
-                try await detailViewModel.getGameDetails(objectID: objectID)
+                try await viewModel.getGameDetails()
                 showDetails()
 
                 self?.activityIndicatorView.stopAnimating()
@@ -115,31 +107,31 @@ private extension DetailViewController {
     }
 
     func showDetails() {
-        nameLabel.text = detailViewModel.name
-        yearLabel.text = detailViewModel.year
-        descriptionLabel.text = detailViewModel.description
+        nameLabel.text = viewModel.name
+        yearLabel.text = viewModel.year
+        descriptionLabel.text = viewModel.description
         descriptionLabel.numberOfLines = 2
         descriptionLabel.lineBreakMode = .byTruncatingTail
         learnMoreButton.isHidden = false
 
-        maximumPlayerLabel.text = detailViewModel.maxPlayer
-        maximumPlayerLabel.isHidden = detailViewModel.isMaxPlayerHidden
-        minimumPlayerLabel.text = detailViewModel.minPlayer
-        minimumPlayerLabel.isHidden = detailViewModel.isMinPlayerHidden
+        maximumPlayerLabel.text = viewModel.maxPlayer
+        maximumPlayerLabel.isHidden = viewModel.isMaxPlayerHidden
+        minimumPlayerLabel.text = viewModel.minPlayer
+        minimumPlayerLabel.isHidden = viewModel.isMinPlayerHidden
 
-        categoryLabel.text = detailViewModel.category
-        categoryLabel.isHidden = detailViewModel.isCategoryHidden
-        publisherLabel.text = detailViewModel.publisher
-        publisherLabel.isHidden = detailViewModel.ispublisherHidden
+        categoryLabel.text = viewModel.category
+        categoryLabel.isHidden = viewModel.isCategoryHidden
+        publisherLabel.text = viewModel.publisher
+        publisherLabel.isHidden = viewModel.ispublisherHidden
 
-        ageLabel.text = detailViewModel.age
-        ageLabel.isHidden = detailViewModel.isAgeHidden
-        playingTimeLabel.text = detailViewModel.playingTime
-        playingTimeLabel.isHidden = detailViewModel.isPlayingTimeHidden
-        minimumPlayingTimeLabel.text = detailViewModel.minimumPlayingTime
-        minimumPlayingTimeLabel.isHidden = detailViewModel.isMinimumPlayingTimeHidden
-        maximumPlayingTimeLabel.text = detailViewModel.maximumPlayingTime
-        maximumPlayingTimeLabel.isHidden = detailViewModel.ismMaximumPlayingTimeHidden
+        ageLabel.text = viewModel.age
+        ageLabel.isHidden = viewModel.isAgeHidden
+        playingTimeLabel.text = viewModel.playingTime
+        playingTimeLabel.isHidden = viewModel.isPlayingTimeHidden
+        minimumPlayingTimeLabel.text = viewModel.minimumPlayingTime
+        minimumPlayingTimeLabel.isHidden = viewModel.isMinimumPlayingTimeHidden
+        maximumPlayingTimeLabel.text = viewModel.maximumPlayingTime
+        maximumPlayingTimeLabel.isHidden = viewModel.ismMaximumPlayingTimeHidden
 
         showImage()
     }
@@ -147,11 +139,11 @@ private extension DetailViewController {
     func showImage() {
         Task { [weak self] in
             do {
-                if let imageURL = detailViewModel.imageURL {
-                   let imageData = try await detailViewModel.getImageData(url: imageURL)
+                if let imageURL = viewModel.imageURL {
+                   let imageData = try await viewModel.getImageData(url: imageURL)
                     self?.imageView.image = UIImage(data: imageData)
-                    self?.imageView.isHidden = detailViewModel.isImageHidden
-                    imageContainerView.isHidden = detailViewModel.isImageHidden
+                    self?.imageView.isHidden = viewModel.isImageHidden
+                    imageContainerView.isHidden = viewModel.isImageHidden
                 }
             } catch {
                 self?.showError(error)

--- a/BoardGameGeek/View/SearchList/BoardGameController.swift
+++ b/BoardGameGeek/View/SearchList/BoardGameController.swift
@@ -77,8 +77,10 @@ private extension BoardGameViewController {
         searchController.searchBar.autocapitalizationType = .none
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.placeholder = "Search a boardgame"
+
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
+        navigationItem.preferredSearchBarPlacement = .stacked
     }
 
     func showError(_ error: Error) {

--- a/BoardGameGeek/View/SearchList/BoardGameController.swift
+++ b/BoardGameGeek/View/SearchList/BoardGameController.swift
@@ -83,15 +83,6 @@ private extension BoardGameViewController {
         navigationItem.preferredSearchBarPlacement = .stacked
     }
 
-    func showError(_ error: Error) {
-        let alertController = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
-        let alertAction = UIAlertAction(title: "OK", style: .default) { [unowned self] _ in
-            self.dismiss(animated: true, completion: nil)
-        }
-        alertController.addAction(alertAction)
-        present(alertController, animated: true, completion: nil)
-    }
-
     func evaluateState() {
         switch boardGameViewModel.state {
         case .loading:
@@ -140,7 +131,7 @@ extension BoardGameViewController: UISearchBarDelegate {
                 self?.searchController.searchBar.text = ""
                 self?.activityIndicatorView.stopAnimating()
                 self?.tableView.isUserInteractionEnabled = true
-                showError(error)
+                self?.showError(error)
             }
         }
 

--- a/BoardGameGeek/View/SearchList/BoardGameTableViewCell.swift
+++ b/BoardGameGeek/View/SearchList/BoardGameTableViewCell.swift
@@ -22,12 +22,6 @@ final class BoardGameTableViewCell: UITableViewCell {
         self.accessoryType = .disclosureIndicator
     }
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-
     override func prepareForReuse() {
         self.yearLabel.isHidden = false
     }

--- a/BoardGameGeek/View/SearchList/EmptyTableViewCell.swift
+++ b/BoardGameGeek/View/SearchList/EmptyTableViewCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class EmptyTableViewCell: UITableViewCell {
+final class EmptyTableViewCell: UITableViewCell {
 
     // MARK: - properties
 
@@ -18,12 +18,6 @@ class EmptyTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
     }
 
     func configure(emptyCellViewModel: EmptyTableCellViewModel) {

--- a/BoardGameGeek/View/ShadowView.swift
+++ b/BoardGameGeek/View/ShadowView.swift
@@ -89,7 +89,6 @@ class ShadowView: UIView {
         self.cornerRadius = self.frame.height / 2
         self.shadowPath = UIBezierPath(roundedRect: self.bounds, cornerRadius: cornerRadius).cgPath
         self.backgroundColor = .clear
-
     }
 
 }

--- a/BoardGameGeek/View/StoryboardProtocol.swift
+++ b/BoardGameGeek/View/StoryboardProtocol.swift
@@ -25,5 +25,4 @@ extension StoryboardProtocol where Self: UIViewController {
 
 }
 
-
 extension UIViewController: StoryboardProtocol {}

--- a/BoardGameGeek/View/StoryboardProtocol.swift
+++ b/BoardGameGeek/View/StoryboardProtocol.swift
@@ -26,3 +26,18 @@ extension StoryboardProtocol where Self: UIViewController {
 }
 
 extension UIViewController: StoryboardProtocol {}
+
+extension StoryboardProtocol where Self: ViewModelProtocol {
+
+  static func instantiate(storyboardName: String, viewModel: ViewModel) -> Self {
+      let storyboardIdentifier = String(describing: self)
+      let storyboard = UIStoryboard(name: storyboardName, bundle: Bundle.main)
+
+      guard let viewController = storyboard.instantiateViewController(withIdentifier: storyboardIdentifier) as? Self else {
+          fatalError("No storyboard with this identifier ")
+      }
+      viewController.viewModel = viewModel
+      return viewController
+  }
+
+}

--- a/BoardGameGeek/ViewModel/Detail/DetailViewModel.swift
+++ b/BoardGameGeek/ViewModel/Detail/DetailViewModel.swift
@@ -11,7 +11,7 @@ final public class DetailViewModel {
 
     // MARK: - properties
 
-    let boardGameService: BoardGameServiceProtocol
+    private let boardGameService: BoardGameServiceProtocol
     var boardGameDetails: BoardGameDetails?
 
     init(boardGameService: BoardGameServiceProtocol) {
@@ -41,12 +41,10 @@ public extension DetailViewModel {
     func getImageData(url: URL) async throws -> Data {
         do {
             return try await boardGameService.getImageData(url: url)
-
         } catch {
             throw error
         }
     }
-
 
 }
 

--- a/BoardGameGeek/ViewModel/Detail/DetailViewModel.swift
+++ b/BoardGameGeek/ViewModel/Detail/DetailViewModel.swift
@@ -12,32 +12,36 @@ final public class DetailViewModel {
     // MARK: - properties
 
     private let boardGameService: BoardGameServiceProtocol
+    private let objectID: String?
     var boardGameDetails: BoardGameDetails?
 
-    init(boardGameService: BoardGameServiceProtocol) {
+    init(boardGameService: BoardGameServiceProtocol, objectID: String?) {
         self.boardGameService = boardGameService
+        self.objectID = objectID
     }
     
 }
 
 public extension DetailViewModel {
 
-    func getGameDetails(objectID: String) async throws {
-        let baseURL = "https://api.geekdo.com/xmlapi/boardgame/"
+    func getGameDetails() async throws {
+        if let objectID = objectID {
+            let baseURL = "https://api.geekdo.com/xmlapi/boardgame/"
 
-        guard let urlString = (baseURL + objectID).addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let url = URL(string: urlString)
-        else {
-            throw BoardGameService.NetworkError.badURL
-        }
-
-        do {
-            let result = try await boardGameService.getData(url: url)
-            if case let .detail(boardGameDetails) = result {
-                self.boardGameDetails = boardGameDetails
+            guard let urlString = (baseURL + objectID).addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+                  let url = URL(string: urlString)
+            else {
+                throw BoardGameService.NetworkError.badURL
             }
-        } catch {
-            throw error
+
+            do {
+                let result = try await boardGameService.getData(url: url)
+                if case let .detail(boardGameDetails) = result {
+                    self.boardGameDetails = boardGameDetails
+                }
+            } catch {
+                throw error
+            }
         }
     }
 

--- a/BoardGameGeek/ViewModel/Detail/DetailViewModel.swift
+++ b/BoardGameGeek/ViewModel/Detail/DetailViewModel.swift
@@ -62,16 +62,12 @@ public extension DetailViewModel {
     }
 
     var description: String {
-        guard let description = boardGameDetails?.description else {
-            return ""
-        }
+        guard let description = boardGameDetails?.description else { return "" }
         return description.removeXML()
     }
 
     var category: String {
-        guard let category = boardGameDetails?.boardGameCategory
-        else { return "" }
-
+        guard let category = boardGameDetails?.boardGameCategory else { return ""}
         return "Category: " + String(category)
     }
 
@@ -80,9 +76,7 @@ public extension DetailViewModel {
     }
 
     var publisher: String {
-        guard let publisher = boardGameDetails?.boardGamePublisher
-        else { return "" }
-
+        guard let publisher = boardGameDetails?.boardGamePublisher else { return "" }
         return "Publisher: " + String(publisher)
     }
 
@@ -91,9 +85,7 @@ public extension DetailViewModel {
     }
 
     var minPlayer: String {
-        guard let minPlayer = boardGameDetails?.minPlayer
-        else { return "" }
-
+        guard let minPlayer = boardGameDetails?.minPlayer else { return "" }
         return "Min Players: " + String(minPlayer)
     }
 
@@ -102,9 +94,7 @@ public extension DetailViewModel {
     }
 
     var maxPlayer: String {
-        guard let maxPlayer = boardGameDetails?.maxPlayer
-        else { return "" }
-
+        guard let maxPlayer = boardGameDetails?.maxPlayer else { return "" }
         return "Max Players: " + String(maxPlayer)
     }
 
@@ -114,12 +104,51 @@ public extension DetailViewModel {
 
     var imageURL: URL? {
         guard let imageURL = boardGameDetails?.imageURL,
-              let url = URL(string: imageURL ) else { return nil }
+              let url = URL(string: imageURL )
+        else {
+            return nil
+        }
         return url
     }
 
     var isImageHidden: Bool {
         imageURL == nil ? true : false
+    }
+
+    var age: String {
+        guard let age = boardGameDetails?.age else { return "" }
+        return "Age: " + String(age)
+    }
+
+    var isAgeHidden: Bool {
+        age.isEmpty ? true : false
+    }
+
+    var playingTime: String {
+        guard let playingTime = boardGameDetails?.playingTime else { return "" }
+        return "Playing Time: " + String(playingTime)
+    }
+
+    var isPlayingTimeHidden: Bool {
+        playingTime.isEmpty ? true : false
+    }
+
+    var minimumPlayingTime: String {
+        guard let minimumPlayingTime = boardGameDetails?.minPlayTime else { return "" }
+        return "Min Playing Time: " + String(minimumPlayingTime)
+    }
+
+    var isMinimumPlayingTimeHidden: Bool {
+        minimumPlayingTime.isEmpty ? true : false
+    }
+
+    var maximumPlayingTime: String {
+        guard let maximumPlayingTime = boardGameDetails?.maxPlayTime else { return "" }
+        return "Max Playing Time: " + String(maximumPlayingTime)
+    }
+
+    var ismMaximumPlayingTimeHidden: Bool {
+        maximumPlayingTime.isEmpty ? true : false
     }
 
 }

--- a/BoardGameGeek/ViewModel/Detail/DetailViewModel.swift
+++ b/BoardGameGeek/ViewModel/Detail/DetailViewModel.swift
@@ -24,7 +24,10 @@ public extension DetailViewModel {
 
     func getGameDetails(objectID: String) async throws {
         let baseURL = "https://api.geekdo.com/xmlapi/boardgame/"
-        guard let url = URL(string: baseURL + objectID) else {
+
+        guard let urlString = (baseURL + objectID).addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: urlString)
+        else {
             throw BoardGameService.NetworkError.badURL
         }
 

--- a/BoardGameGeek/ViewModel/SearchList/BoardGameViewModel.swift
+++ b/BoardGameGeek/ViewModel/SearchList/BoardGameViewModel.swift
@@ -45,7 +45,10 @@ extension BoardGameViewModel {
 
     func getGames(searchString: String) async throws {
         let baseURL = "https://api.geekdo.com/xmlapi/search?search="
-        guard let url = URL(string: baseURL + searchString) else {
+
+        guard let urlString = (baseURL + searchString).addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: urlString)
+        else {
             throw BoardGameService.NetworkError.badURL
         }
 

--- a/BoardGameGeek/ViewModel/SearchList/BoardGameViewModel.swift
+++ b/BoardGameGeek/ViewModel/SearchList/BoardGameViewModel.swift
@@ -30,7 +30,7 @@ final public class BoardGameViewModel {
 
     // MARK: - properties
 
-    let boardGameService: BoardGameServiceProtocol
+    private let boardGameService: BoardGameServiceProtocol
     var boardGames: [BoardGame]
     public var state: State
 

--- a/BoardGameGeek/ViewModel/SearchList/BoardGameViewModel.swift
+++ b/BoardGameGeek/ViewModel/SearchList/BoardGameViewModel.swift
@@ -28,6 +28,10 @@ final public class BoardGameViewModel {
         case empty
     }
 
+    enum PushedViewModel {
+        case detail(DetailViewModel)
+    }
+
     // MARK: - properties
 
     private let boardGameService: BoardGameServiceProtocol
@@ -67,9 +71,15 @@ extension BoardGameViewModel {
         }
     }
 
-    func selectItem(row: Int) -> String? {
+    func selectItem(row: Int) -> PushedViewModel? {
         if boardGames.indices.contains(row) {
-            return boardGames[row].objectid
+            return
+                .detail(
+                    DetailViewModel(
+                        boardGameService: BoardGameService(parser: DetailParser()),
+                        objectID: boardGames[row].objectid
+                    )
+                )
         }
 
         return nil

--- a/BoardGameGeek/ViewModel/ViewModelProtocol.swift
+++ b/BoardGameGeek/ViewModel/ViewModelProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  viewModelProtocol.swift
+//  BoardGameGeek
+//
+//  Created by Nafisa Rahman on 30/1/2023.
+//
+
+import Foundation
+
+protocol ViewModelProtocol: AnyObject {
+  associatedtype ViewModel
+
+  var viewModel: ViewModel! { get set }
+}


### PR DESCRIPTION
**Summary:**

This PR 
- displays some more info on the board game detail screen
- makes description expandable by tapping on Learn more button
- some refactoring

**Note:**
Tests will be written in a later PR.

**Screenshot:**

<img src="https://user-images.githubusercontent.com/61398249/215387814-3bed0351-9de7-4203-bfdf-f361dd1a30b3.png"   height="400">

<img src="https://user-images.githubusercontent.com/61398249/215387659-8a0ef9e0-eb94-46f9-a23e-78628a0fb276.png"   height="400">
